### PR TITLE
Update GitHub workflow node version

### DIFF
--- a/.github/workflows/webpack.yml
+++ b/.github/workflows/webpack.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [20.x]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
The node-version in GitHub workflow configuration (webpack.yml) is updated from multiple versions (16.x, 18.x) to a single version (20.x). This update is made to align with our latest node.js requirements for smooth build and deployment.